### PR TITLE
Hp output dir change

### DIFF
--- a/lib/export_parameter_to_file.js
+++ b/lib/export_parameter_to_file.js
@@ -54,7 +54,7 @@ function callSsm(parameter_names, callback) {
 }
 
 function writeResponseToFile(ssmResponse, callback) {
-  const outputs_dir = './data';
+  const outputs_dir = '/tmp';
   if (!fs.existsSync(outputs_dir)){
       fs.mkdirSync(outputs_dir);
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newman-aws-utils",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Utilities to run newman leveraging aws services",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
commit 47b1747cf2f44c9795f70a61297ff080cdafa330 

    Bumps up the version

commit bde52ce930569c73b8261cb52868e3a6768c97d0

    Changes output dir to /tmp

    Lambda functions can only write to /tmp